### PR TITLE
Relative paths

### DIFF
--- a/lib/buster-lint.js
+++ b/lib/buster-lint.js
@@ -4,9 +4,9 @@ function processor(analyzer, resource, content) {
     // Temporary work-around for buster peculiarities
     if (!content) { return; }
 
-    var result = this.checker.check(content, resource.path);
+    var path = "." + resource.path;
+    var result = this.checker.check(content, path);
     if (!result.ok) {
-        var path = resource.path;
         analyzer.error("Lint in " + path, result);
     }
 }

--- a/test/buster-lint-test.js
+++ b/test/buster-lint-test.js
@@ -22,7 +22,7 @@ buster.testCase("Lint extension", {
         group.resolve().then(function (resourceSet) {
             resourceSet.serialize().then(done(function () {
                 assert.calledOnceWith(this.listeners.error,
-                                      "Lint in /buster.js");
+                                      "Lint in ./buster.js");
             }.bind(this)), function (err) {
                 buster.log(err.message, err.stack);
             });


### PR DESCRIPTION
The resource set uses absolute paths (e.g. `/lib/jquery.js`). Add a dot in front so the paths can be copied and used with e.g. `emacsclient`
