### PR TITLE
Extension needs a name

### DIFF
--- a/lib/buster-lint.js
+++ b/lib/buster-lint.js
@@ -12,6 +12,8 @@ function processor(analyzer, resource, content) {
 }
 
 module.exports = {
+    name: "buster-lint",
+
     create: function (options) {
         var instance = Object.create(this);
         instance.checker = lint.create(options || {});


### PR DESCRIPTION
Extensions can no longer be configured with strings, e.g. `extensions: ["buster-lint"]`. You have to require them, which means the extension now needs to carry its own name in order to take custom configuration.
